### PR TITLE
note about implicit build order

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,9 @@
 openmrs-module-basicmodule
 ==========================
 
-A demonstration module for new OpenMRS module developers
+A demonstration module for new OpenMRS module developers.
+
+NOTE: please build the "install" target first.  Some other targets
+(such as "test") implicitly depend on artifacts that are built by the
+"install" target so they'll fail unless the "install" target has been
+built first.


### PR DESCRIPTION
If you clone and then try to "mvn test" it will fail with:

[INFO] ------------------------------------------------------------------------
[ERROR] BUILD ERROR
[INFO] ------------------------------------------------------------------------
[INFO] Error unpacking file: /home/tobyc/try/openmrs-module-basicmodule/api/target/classes to: /home/tobyc/try/openmrs-module-basicmodule/omod/target/classes
org.codehaus.plexus.archiver.ArchiverException: The source must not be a directory.

Building the "install" target fixes this so I added a note to the README telling devs to do that first.

The real fix would be to have the "test" target explicitly depend on the "install" target but I'm not mvn-savvy enough to do that.
