### PR TITLE
Fix module activator

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -11,19 +11,4 @@
 	<packaging>jar</packaging>
 	<name>Basic Module API</name>
 	<description>API project for Basic Module</description>
-
-	<dependencies>
-        <dependency>
-            <groupId>org.openmrs.api</groupId>
-            <artifactId>openmrs-api</artifactId>
-            <type>jar</type>
-            <scope>provided</scope>
-            <exclusions>
-                 <exclusion>
-                     <groupId>javassist</groupId>
-                     <artifactId>javassist</artifactId>
-                 </exclusion>
-            </exclusions>
-        </dependency>
-	</dependencies>
 </project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -11,4 +11,19 @@
 	<packaging>jar</packaging>
 	<name>Basic Module API</name>
 	<description>API project for Basic Module</description>
+
+	<dependencies>
+        <dependency>
+            <groupId>org.openmrs.api</groupId>
+            <artifactId>openmrs-api</artifactId>
+            <type>jar</type>
+            <scope>provided</scope>
+            <exclusions>
+                 <exclusion>
+                     <groupId>javassist</groupId>
+                     <artifactId>javassist</artifactId>
+                 </exclusion>
+            </exclusions>
+        </dependency>
+	</dependencies>
 </project>

--- a/api/src/main/java/org/openmrs/module/basicmodule/BasicModuleActivator.java
+++ b/api/src/main/java/org/openmrs/module/basicmodule/BasicModuleActivator.java
@@ -15,12 +15,12 @@ package org.openmrs.module.basicmodule;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.openmrs.module.Activator;
+import org.openmrs.module.BaseModuleActivator;
 
 /**
  * This class contains the logic that is run every time this module is either started or shutdown
  */
-public class BasicModuleActivator implements Activator {
+public class BasicModuleActivator extends BaseModuleActivator {
 	
 	private Log log = LogFactory.getLog(this.getClass());
 	


### PR DESCRIPTION
The class BasicModuleActivator was implementing Activator (currently deprecated); this resulted to the module failing to start. This PR fixes the issue by extending BaseModuleActivator.